### PR TITLE
Cam/pascal case

### DIFF
--- a/.changeset/nine-chefs-cross.md
+++ b/.changeset/nine-chefs-cross.md
@@ -1,0 +1,5 @@
+---
+'@relevanceai/eslint-plugin': minor
+---
+
+feat: add pascal-case rule

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
         with:
-          version: 9
+          version: 10
       - uses: actions/setup-node@v3
         with:
           node-version: 20.x

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This package contains custom ESLint rules that we use here at [Relevance AI](htt
 
 ## Rule overviews
 
-See the implementation for more specifics.
+See the implementations for more specifics.
 
 ### no-vitest-and-expect-package
 
@@ -10,11 +10,46 @@ This rule errors when importing from both `expect` and `vitest` in the same file
 
 ### prefer-function-as-describe-label
 
-TODO?
+This rule errors when a string literal or `Function.name` is passed to Vitest's `describe` function. You should pass the function directly, so the describe block name stays in-sync with the function name.
+
+Bad:
+
+```js
+function Foo() {}
+describe('Foo', () => {})
+```
+
+```js
+function Foo() {}
+describe(Foo.name, () => {})
+```
+
+Good:
+
+```js
+function Foo() {}
+describe(Foo, () => {})
+```
 
 ### prefer-vi-mock-import-expression
 
-TODO?
+This rule errors when passing a path to `vi.mock`. You should pass an import expression instead as this:
+
+- makes `vi.mock` type-safe since we can't refer to modules that don't exist.
+- allows TypeScript to infer the correct type for the mock factory (2nd arg to `vi.mock`).
+- makes refactoring by moving files around easier since VSCode updates import expressions when you do.
+
+Bad:
+
+```js
+vi.mock('~/dependencies', () => {})
+```
+
+Good:
+
+```js
+vi.mock(import('~/dependencies'), () => {})
+```
 
 ### pascal-case
 

--- a/README.md
+++ b/README.md
@@ -18,4 +18,19 @@ TODO?
 
 ### pascal-case
 
-TODO?
+This rule errors when a variable, containing a function, doesn't have a PascalCase name.
+The rule was written to replace @typescript-eslint/naming-convention for our needs, since it was taking up about 25 seconds, or about 40%, of the time taken to lint one of our repos.
+
+Bad:
+
+```js
+const foo = () => {}
+```
+
+Good:
+
+```js
+const Foo = () => {}
+```
+
+We intentionally don't generate fixes for the naming violations, since that would require analysing which parts of a variable are words/acronyms.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,21 @@
 This package contains custom ESLint rules that we use here at [Relevance AI](https://relevanceai.com/). These rules aren't intended for public usage (some of them are quite specific and opinionated), so we don't recommend using them in your projects.
 
 ## Rule overviews
+
 See the implementation for more specifics.
 
 ### no-vitest-and-expect-package
+
 This rule errors when importing from both `expect` and `vitest` in the same file. When using vitest, you should use its version of `expect()`.
+
 ### prefer-function-as-describe-label
+
 TODO?
+
 ### prefer-vi-mock-import-expression
+
 TODO?
-### pascal-case-functions-and-types
+
+### pascal-case
+
 TODO?

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-eslint stuff
+This package contains custom ESLint rules that we use here at [Relevance AI](https://relevanceai.com/). These rules aren't intended for public usage (some of them are quite specific and opinionated), so we don't recommend using them in your projects.
+
+## Rule overviews
+See the implementation for more specifics.
+
+### no-vitest-and-expect-package
+This rule errors when importing from both `expect` and `vitest` in the same file. When using vitest, you should use its version of `expect()`.
+### prefer-function-as-describe-label
+TODO?
+### prefer-vi-mock-import-expression
+TODO?
+### pascal-case-functions-and-types
+TODO?

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.27.11",
+    "@types/estree": "^1.0.6",
     "@types/node": "^22.13.0",
     "eslint": "^9.18.0",
     "prettier": "^3.4.2"
-  }
+  },
+  "packageManager": "pnpm@10.11.1+sha512.e519b9f7639869dc8d5c3c5dfef73b3f091094b0a006d7317353c72b124e80e1afd429732e28705ad6bfa1ee879c1fce46c128ccebd3192101f43dd67c667912"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@relevanceai/eslint-plugin",
   "version": "0.4.0",
-  "description": "eslint stuff",
+  "description": "Relevance AI ESLint rules",
   "type": "commonjs",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.11
         version: 2.27.12
+      '@types/estree':
+        specifier: ^1.0.6
+        version: 1.0.6
       '@types/node':
         specifier: ^22.13.0
         version: 22.13.0

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -4,6 +4,7 @@ const plugin = {
     'prefer-vi-mock-import-expression': require('./rules/prefer-vi-mock-import-expression'),
     'no-vitest-and-expect-package': require('./rules/no-vitest-and-expect-package'),
     'prefer-function-as-describe-label': require('./rules/prefer-function-as-describe-label'),
+    'pascal-case': require('./rules/pascal-case'),
   },
 }
 

--- a/src/rules/pascal-case-functions-and-types.js
+++ b/src/rules/pascal-case-functions-and-types.js
@@ -1,8 +1,99 @@
+/*
+
+This rule looks at each variable and tries to determine if it's a
+function/callable. If it is, then the variable is expected to have a PascalCase
+name.
+
+The rule was written to replace @typescript-eslint/naming-convention for our
+needs, since it was taking up about 25 seconds, or about 40%, of the time taken
+to lint one of our repos.
+
+This rule is faster because it doesn't need to use TypeScript to calculate the
+type of every variable and check if it's a function - we just use syntactic
+analysis and some hardcoded special cases based on the functions used in our
+repo.
+
+The hardcoded cases for Vitest are:
+  - methods that are only called on mocked functions:
+    -mockResolvedValue
+    -mockResolvedValueOnce
+    -mockReturnValue
+    -mockReturnValueOnce
+    -mockImplementation
+    -mockImplementationOnce
+    -mockRejectedValue
+    -mockRejectedValueOnce
+    -mockReturnThis
+  - vi.fn()
+  - vi.mocked().X() where X is one of the methods that are only called on mocked
+    functions.
+  - expect(foo).X(), where X is one of the methods that are only called on
+    expect for functions:
+    - toHaveBeenCalledTimes
+    - toHaveBeenCalledWith
+    - toHaveBeenCalledOnce
+
+We use these values to infer that a variable is a function even we we don't see
+a function being assigned to a variable.
+
+The test for PascalCase is quite primitive/liberal (borrowed from
+@typescript-eslint/naming-convention), and we intentionally don't generate fixes
+for the naming violations, since that would require analysing which parts of a
+variable are words/acronyms.
+
+In the following cases, we use these definitions/meanings:
+- RHS = right hand side = "the thing assigned to a variable".
+- MemberExpression is property access, and we only consider non-computed
+  MemberExpressions.
+
+Assignment based cases:
+Case 1: Variable has a function assigned to it, or is declared with a function
+as the initial value.
+  a. RHS is arrow function or function expression:
+    const foo = () => {};
+    const foo = function() {};
+
+  b. RHS is a call to a known function factory (function that returns functions):
+    const foo = KnownFunctionFactory();
+
+  c. RHS is a MemberExpression and the property name is PascalCase (indicating
+  that it's a function in our convention):
+    const foo = someObject.SomeFunction;
+
+  d. RHS is a CallExpression, optionally with member function calls chained onto
+  it if the methods are known Vitest function mocking methods.
+  The callee must be either:
+    1. A MemberExpression of the form `vi.fn()`, with optionally one argument:
+      const foo = vi.fn();
+      const foo = vi.fn(() => {});
+      const foo = vi.fn().mockResolvedValue().mockRejectedValue();
+
+    2. A MemberExpression of the form `vi.mocked(args)`, where args is either
+    a PascalCase identifier, or a MemberExpression with a PascalCase property:
+      const foo = vi.mocked(SomeFunction);
+      const foo = vi.mocked(obj.SomeFunction);
+
+Usage based cases:
+Case 2:
+  a. The variable is called:
+    const foo = blah; foo();
+  b. The variable has a known Vitest function mocking method called on it:
+    const foo = blah; foo.mockResolvedValue();
+  c. The variable is passed as the sole argument to Vitest's `expect` function,
+  which then has a known Vitest expect method for functions:
+    const foo = blah; expect(foo).toHaveBeenCalledTimes();
+
+*/
+
 /**
  * @type {import('eslint').Rule.RuleModule}
  */
 module.exports = {
   meta: {
+    docs: {
+      description:
+        'Ensure all variables that contain functions have PascalCase names.',
+    },
     type: 'problem',
     schema: [
       {
@@ -32,6 +123,7 @@ module.exports = {
 
     return {
       VariableDeclarator(node) {
+        // Case 1. for declarations.
         if (node.id.type === 'Identifier') {
           if (node.init && isRHSFunction(node.init, knownFunctionFactories)) {
             const name = node.id.name
@@ -71,6 +163,7 @@ function checkVariable(
   references,
   knownFunctionFactories,
 ) {
+  // Case 2.a.
   const isCalled = references.some((r) => {
     const parent = r.identifier.parent
     return parent.type === 'CallExpression' && parent.callee === r.identifier
@@ -80,6 +173,7 @@ function checkVariable(
     checkAndReport(context, bindingIdentifiers, name)
   }
 
+  // Case 1. for assignments.
   const isAssignedAFunction = references.some((r) => {
     const parent = r.identifier.parent
     if (
@@ -96,8 +190,7 @@ function checkVariable(
     checkAndReport(context, bindingIdentifiers, name)
   }
 
-  // const something = vi.mocked(...);
-  // something.mockImplementation(...);
+  // Case 2.b.
   const hasKnownViTestFunctionMockCall = references.some((r) => {
     const parent = r.identifier.parent
     if (
@@ -128,6 +221,7 @@ function checkVariable(
     checkAndReport(context, bindingIdentifiers, name)
   }
 
+  // Case 2.c.
   const usedInExpectToHaveBeenCalledTimes = references.some((r) => {
     const parent = r.identifier.parent
     if (
@@ -166,6 +260,7 @@ function checkVariable(
  * @param {Set<string> | undefined} knownFunctionFactories
  */
 function isRHSFunction(rhs, knownFunctionFactories) {
+  // Case 1.a.
   if (
     rhs.type === 'ArrowFunctionExpression' ||
     rhs.type === 'FunctionExpression'
@@ -173,6 +268,7 @@ function isRHSFunction(rhs, knownFunctionFactories) {
     return true
   }
 
+  // Case 1.b.
   if (
     rhs.type === 'CallExpression' &&
     rhs.callee.type === 'Identifier' &&
@@ -181,6 +277,7 @@ function isRHSFunction(rhs, knownFunctionFactories) {
     return true
   }
 
+  // Case 1.c.
   if (
     rhs.type === 'MemberExpression' &&
     !rhs.computed &&
@@ -190,19 +287,7 @@ function isRHSFunction(rhs, knownFunctionFactories) {
     return true
   }
 
-  /**
-   * @param {import("estree").CallExpression} call
-   */
-  function getLeftMostCall(call) {
-    while (
-      call.callee.type === 'MemberExpression' &&
-      call.callee.object.type === 'CallExpression'
-    ) {
-      call = call.callee.object
-    }
-    return call
-  }
-
+  // Case 1.d.
   if (rhs.type === 'CallExpression') {
     const leftMostCall = getLeftMostCall(rhs)
 
@@ -213,6 +298,15 @@ function isRHSFunction(rhs, knownFunctionFactories) {
       leftMostCall.callee.object.name === 'vi' &&
       leftMostCall.callee.property.type === 'Identifier'
     ) {
+      // Case 1.d.1.
+      if (
+        leftMostCall.callee.property.name === 'fn' &&
+        leftMostCall.arguments.length <= 1
+      ) {
+        return true
+      }
+
+      // Case 1.d.2.
       if (
         leftMostCall.callee.property.name === 'mocked' &&
         leftMostCall.arguments.length === 1
@@ -232,17 +326,23 @@ function isRHSFunction(rhs, knownFunctionFactories) {
           return true
         }
       }
-
-      if (
-        leftMostCall.callee.property.name === 'fn' &&
-        leftMostCall.arguments.length <= 1
-      ) {
-        return true
-      }
     }
   }
 
   return false
+}
+
+/**
+ * @param {import("estree").CallExpression} call
+ */
+function getLeftMostCall(call) {
+  while (
+    call.callee.type === 'MemberExpression' &&
+    call.callee.object.type === 'CallExpression'
+  ) {
+    call = call.callee.object
+  }
+  return call
 }
 
 /**

--- a/src/rules/pascal-case-functions-and-types.js
+++ b/src/rules/pascal-case-functions-and-types.js
@@ -102,7 +102,8 @@ module.exports = {
                 grandparent?.type === 'MemberExpression' &&
                 grandparent.property.type === 'Identifier' &&
                 (grandparent.property.name === 'toHaveBeenCalledTimes' ||
-                  grandparent.property.name === 'toHaveBeenCalledWith')
+                  grandparent.property.name === 'toHaveBeenCalledWith' ||
+                  grandparent.property.name === 'toHaveBeenCalledOnce')
               ) {
                 const greatGrandParent = grandparent.parent
                 if (

--- a/src/rules/pascal-case-functions-and-types.js
+++ b/src/rules/pascal-case-functions-and-types.js
@@ -1,0 +1,207 @@
+/**
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'TODO',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      VariableDeclarator(node) {
+        if (node.id.type !== 'Identifier') {
+          return
+        }
+
+        const name = node.id.name
+
+        if (node.init && isRHSFunction(node.init)) {
+          checkAndReport(context, node, name)
+
+          return
+        }
+
+        const sourceCode = context.sourceCode
+        const scope = sourceCode.getScope(node.id)
+        const variable = scope.variables.find((v) => v.name === name)
+
+        if (!variable) {
+          return
+        }
+
+        const isCalled = variable.references.some((r) => {
+          const parent = r.identifier.parent
+          return (
+            parent.type === 'CallExpression' && parent.callee === r.identifier
+          )
+        })
+
+        if (isCalled) {
+          checkAndReport(context, node, name)
+        }
+
+        const isAssignedAFunction = variable.references.some((r) => {
+          const parent = r.identifier.parent
+          if (
+            parent.type === 'AssignmentExpression' &&
+            parent.left === r.identifier
+          ) {
+            if (isRHSFunction(parent.right)) {
+              return true
+            }
+          }
+        })
+
+        if (isAssignedAFunction) {
+          checkAndReport(context, node, name)
+        }
+
+        const hasKnownViTestFunctionMockCall = variable.references.some((r) => {
+          const parent = r.identifier.parent
+          if (
+            parent.type === 'MemberExpression' &&
+            !parent.computed &&
+            parent.object === r.identifier &&
+            (parent.property.name === 'mockResolvedValue' ||
+              parent.property.name === 'mockResolvedValueOnce' ||
+              parent.property.name === 'mockReturnValue' ||
+              parent.property.name === 'mockReturnValueOnce')
+          ) {
+            const grandparent = parent.parent
+            if (
+              grandparent.type === 'CallExpression' &&
+              grandparent.callee === parent
+            ) {
+              return true
+            }
+          }
+        })
+
+        if (hasKnownViTestFunctionMockCall) {
+          checkAndReport(context, node, name)
+        }
+      },
+    }
+  },
+}
+
+/**
+ * @param {import("estree").Expression} rhs
+ */
+function isRHSFunction(rhs) {
+  if (
+    rhs.type === 'ArrowFunctionExpression' ||
+    rhs.type === 'FunctionExpression'
+  ) {
+    return true
+  }
+
+  if (
+    rhs.type === 'MemberExpression' &&
+    !rhs.computed &&
+    rhs.property.type === "Identifier" &&
+    
+    isPascalCase(rhs.property.name)
+  ) {
+    return true
+  }
+
+  if (rhs.type === 'CallExpression') {
+    let currentCall = rhs
+    while (true) {
+      if (
+        currentCall.callee.type === 'MemberExpression' &&
+        !currentCall.callee.computed
+      ) {
+        if (
+          currentCall.callee.object.type === 'Identifier' &&
+          currentCall.callee.object.name === 'vi' &&
+          currentCall.callee.property.type === 'Identifier' &&
+          currentCall.callee.property.name === 'mocked' &&
+          currentCall.arguments.length === 1
+        ) {
+          if (
+            currentCall.arguments[0]?.type === 'Identifier' &&
+            isPascalCase(currentCall.arguments[0].name)
+          ) {
+            return true
+          }
+
+          const argument = currentCall.arguments[0]
+          if (
+            argument?.type === 'MemberExpression' &&
+            !argument.computed &&
+            argument.property.type === 'Identifier' &&
+            isPascalCase(argument.property.name)
+          ) {
+            return true
+          }
+        }
+
+        if (currentCall.callee.object.type === 'CallExpression') {
+          currentCall = currentCall.callee.object
+          continue
+        }
+      }
+
+      break
+    }
+  }
+
+  if (rhs.type === 'CallExpression') {
+    let currentCall = rhs
+    while (true) {
+      if (
+        currentCall.callee.type === 'MemberExpression' &&
+        !currentCall.callee.computed
+      ) {
+        if (
+          currentCall.callee.object.type === 'Identifier' &&
+          currentCall.callee.object.name === 'vi' &&
+          currentCall.callee.property.type === 'Identifier' &&
+          currentCall.callee.property.name === 'fn' &&
+          currentCall.arguments.length <= 1
+        ) {
+          return true
+        }
+
+        if (currentCall.callee.object.type === 'CallExpression') {
+          currentCall = currentCall.callee.object
+          continue
+        }
+      }
+
+      break
+    }
+  }
+
+  return false
+}
+
+/**
+ * @param {string} name
+ */
+// https://github.com/typescript-eslint/typescript-eslint/blob/db32b8a82d58eddb29be207a5f4476644973abbf/packages/eslint-plugin/src/rules/naming-convention-utils/format.ts#L17
+function isPascalCase(name) {
+  return (
+    name.length === 0 ||
+    (name[0] === name[0]?.toUpperCase() && !name.includes('_'))
+  )
+}
+
+/**
+ * @param {import("eslint").Rule.RuleContext} context
+ * @param {import("estree").Node} node
+ * @param {string} name
+ */
+function checkAndReport(context, node, name) {
+  if (!isPascalCase(name)) {
+    context.report({
+      node,
+      message: `Function variable '${name}' must have PascalCase name`,
+    })
+  }
+}

--- a/src/rules/pascal-case-functions-and-types.js
+++ b/src/rules/pascal-case-functions-and-types.js
@@ -64,7 +64,8 @@ module.exports = {
             (parent.property.name === 'mockResolvedValue' ||
               parent.property.name === 'mockResolvedValueOnce' ||
               parent.property.name === 'mockReturnValue' ||
-              parent.property.name === 'mockReturnValueOnce')
+              parent.property.name === 'mockReturnValueOnce' ||
+              parent.property.name === 'mockImplementation')
           ) {
             const grandparent = parent.parent
             if (

--- a/src/rules/pascal-case-functions-and-types.js
+++ b/src/rules/pascal-case-functions-and-types.js
@@ -55,6 +55,8 @@ module.exports = {
           checkAndReport(context, node, name)
         }
 
+        // const something = vi.mocked(...);
+        // something.mockImplementation(...);
         const hasKnownViTestFunctionMockCall = variable.references.some((r) => {
           const parent = r.identifier.parent
           if (
@@ -66,8 +68,10 @@ module.exports = {
               parent.property.name === 'mockReturnValue' ||
               parent.property.name === 'mockReturnValueOnce' ||
               parent.property.name === 'mockImplementation' ||
+              parent.property.name === 'mockImplementationOnce' ||
               parent.property.name === 'mockRejectedValue' ||
-              parent.property.name === 'mockRejectedValueOnce')
+              parent.property.name === 'mockRejectedValueOnce' ||
+              parent.property.name === 'mockReturnThis')
           ) {
             const grandparent = parent.parent
             if (

--- a/src/rules/pascal-case.js
+++ b/src/rules/pascal-case.js
@@ -183,7 +183,8 @@ function checkVariable(
 ) {
   // Case 2.a.
   const isCalled = references.some((r) => {
-    const parent = r.identifier.parent
+    const parent = /** @type {import('eslint').Rule.Node} */ (r.identifier)
+      .parent
     return parent.type === 'CallExpression' && parent.callee === r.identifier
   })
 
@@ -193,7 +194,8 @@ function checkVariable(
 
   // Case 1. for assignments.
   const isAssignedAFunction = references.some((r) => {
-    const parent = r.identifier.parent
+    const parent = /** @type {import('eslint').Rule.Node} */ (r.identifier)
+      .parent
     if (
       parent.type === 'AssignmentExpression' &&
       parent.left === r.identifier
@@ -210,10 +212,12 @@ function checkVariable(
 
   // Case 2.b.
   const hasKnownViTestFunctionMockCall = references.some((r) => {
-    const parent = r.identifier.parent
+    const parent = /** @type {import('eslint').Rule.Node} */ (r.identifier)
+      .parent
     if (
       parent.type === 'MemberExpression' &&
       !parent.computed &&
+      parent.property.type === 'Identifier' &&
       parent.object === r.identifier &&
       KNOWN_VITEST_FUNCTION_MOCK_METHODS.has(parent.property.name)
     ) {
@@ -231,35 +235,12 @@ function checkVariable(
     checkAndReport(context, bindingIdentifiers, name)
   }
 
-  // /**
-  //  * @param {import("eslint").Rule.RuleContext} context
-  //  * @param {import('estree').Node} node
-  //  */
-  // function isVitestExpect(context, node) {
-  //   if (node.type !== 'Identifier' || node.name !== 'expect') {
-  //     return false
-  //   }
-  //   const scope = context.sourceCode.getScope(node)
-  //   const variable = scope.variables.find((v) => v.name === node.name)
-  //   if (!variable) {
-  //     return false
-  //   }
-  //   return variable.defs.some((def) => {
-  //     return (
-  //       def.type === 'ImportBinding' &&
-  //       def.parent?.type === 'ImportDeclaration' &&
-  //       def.parent.source.type === 'Literal' &&
-  //       def.parent.source.value === 'vitest'
-  //     )
-  //   })
-  // }
-
   // Case 2.c.
   const usedInExpectToHaveBeenCalledTimes = references.some((r) => {
-    const parent = r.identifier.parent
+    const parent = /** @type {import('eslint').Rule.Node} */ (r.identifier)
+      .parent
     if (
       parent.type === 'CallExpression' &&
-      // isVitestExpect(context, parent.callee) &&
       parent.callee.type === 'Identifier' &&
       parent.callee.name === 'expect' &&
       parent.arguments.length === 1 &&

--- a/src/rules/pascal-case.js
+++ b/src/rules/pascal-case.js
@@ -231,11 +231,35 @@ function checkVariable(
     checkAndReport(context, bindingIdentifiers, name)
   }
 
+  // /**
+  //  * @param {import("eslint").Rule.RuleContext} context
+  //  * @param {import('estree').Node} node
+  //  */
+  // function isVitestExpect(context, node) {
+  //   if (node.type !== 'Identifier' || node.name !== 'expect') {
+  //     return false
+  //   }
+  //   const scope = context.sourceCode.getScope(node)
+  //   const variable = scope.variables.find((v) => v.name === node.name)
+  //   if (!variable) {
+  //     return false
+  //   }
+  //   return variable.defs.some((def) => {
+  //     return (
+  //       def.type === 'ImportBinding' &&
+  //       def.parent?.type === 'ImportDeclaration' &&
+  //       def.parent.source.type === 'Literal' &&
+  //       def.parent.source.value === 'vitest'
+  //     )
+  //   })
+  // }
+
   // Case 2.c.
   const usedInExpectToHaveBeenCalledTimes = references.some((r) => {
     const parent = r.identifier.parent
     if (
       parent.type === 'CallExpression' &&
+      // isVitestExpect(context, parent.callee) &&
       parent.callee.type === 'Identifier' &&
       parent.callee.name === 'expect' &&
       parent.arguments.length === 1 &&

--- a/src/rules/pascal-case.js
+++ b/src/rules/pascal-case.js
@@ -181,6 +181,17 @@ function checkVariable(
   references,
   knownFunctionFactories,
 ) {
+  const isDestructuringAssignmentShorthandProperty = bindingIdentifiers.some(
+    (ident) => {
+      const parent = /** @type {import('eslint').Rule.Node} */ (ident).parent
+      return parent.type === 'Property' && parent.shorthand
+    },
+  )
+
+  if (isDestructuringAssignmentShorthandProperty) {
+    return false
+  }
+
   // Case 2.a.
   const isCalled = references.some((r) => {
     const parent = /** @type {import('eslint').Rule.Node} */ (r.identifier)

--- a/src/rules/pascal-case.js
+++ b/src/rules/pascal-case.js
@@ -57,11 +57,7 @@ as the initial value.
   b. RHS is a call to a known function factory (function that returns functions):
     const foo = KnownFunctionFactory();
 
-  c. RHS is a MemberExpression and the property name is PascalCase (indicating
-  that it's a function in our convention):
-    const foo = someObject.SomeFunction;
-
-  d. RHS is a CallExpression, optionally with member function calls chained onto
+  c. RHS is a CallExpression, optionally with member function calls chained onto
   it if the methods are known Vitest function mocking methods.
   The callee must be either:
     1. A MemberExpression of the form `vi.fn()`, with optionally one argument:
@@ -304,16 +300,6 @@ function isRHSFunction(rhs, knownFunctionFactories) {
   }
 
   // Case 1.c.
-  if (
-    rhs.type === 'MemberExpression' &&
-    !rhs.computed &&
-    rhs.property.type === 'Identifier' &&
-    isPascalCase(rhs.property.name)
-  ) {
-    return true
-  }
-
-  // Case 1.d.
   if (rhs.type === 'CallExpression') {
     const leftMostCall = getLeftMostCall(
       rhs,
@@ -332,7 +318,7 @@ function isRHSFunction(rhs, knownFunctionFactories) {
       leftMostCall.callee.object.name === 'vi' &&
       leftMostCall.callee.property.type === 'Identifier'
     ) {
-      // Case 1.d.1.
+      // Case 1.c.1.
       if (
         leftMostCall.callee.property.name === 'fn' &&
         leftMostCall.arguments.length <= 1
@@ -340,17 +326,17 @@ function isRHSFunction(rhs, knownFunctionFactories) {
         return true
       }
 
-      // Case 1.d.2-3.
+      // Case 1.c.2-3.
       if (
         leftMostCall.callee.property.name === 'mocked' &&
         leftMostCall.arguments.length === 1
       ) {
-        // Case 1.d.3.
+        // Case 1.c.3.
         if (hasKnownViTestFunctionMockCall) {
           return true
         }
 
-        // Case 1.d.2.
+        // Case 1.c.2.
         const argument = leftMostCall.arguments[0]
 
         if (argument?.type === 'Identifier' && isPascalCase(argument.name)) {


### PR DESCRIPTION
This PR adds a new PascalCase rule.
This rule errors when a variable, containing a function, doesn't have a PascalCase name.
It's written to replace @typescript-eslint/naming-convention for our needs, since it was taking up about 25 seconds, or about 40%, of the time taken to lint our backend repo.

I've written documentation (maybe too much😅) in the code, so check that our for more details